### PR TITLE
feat: close dropdown on item click

### DIFF
--- a/src/components/ExportDropdown.tsx
+++ b/src/components/ExportDropdown.tsx
@@ -1,7 +1,14 @@
 import { FC } from "react";
-import { exportAsImage } from "@/utils";
+import { exportAsImage, closeDropdownOnItemClick } from "@/utils";
+import { ExportOptions } from "@/types/export";
 
 export const ExportDropdown: FC = () => {
+  const handleExport =
+    (selector: string, option: ExportOptions, filename?: string) => () => {
+      exportAsImage(selector, option, filename);
+      closeDropdownOnItemClick();
+    };
+
   return (
     <div className="dropdown">
       <button
@@ -17,7 +24,7 @@ export const ExportDropdown: FC = () => {
         <li>
           <button
             className="btn-ghost"
-            onClick={() => exportAsImage(".grid", "download", "stats")}
+            onClick={handleExport(".grid", "download", "stats")}
           >
             Download as PNG
           </button>
@@ -25,7 +32,7 @@ export const ExportDropdown: FC = () => {
         <li>
           <button
             className="btn-ghost"
-            onClick={() => exportAsImage(".grid", "clipboard")}
+            onClick={handleExport(".grid", "clipboard")}
           >
             Copy to Clipboard
           </button>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,10 +3,14 @@ import { signIn, signOut, useSession } from "next-auth/react";
 import Image from "next/image";
 import Link from "next/link";
 import { ThemeSelector } from "./ThemeSelector";
+import { closeDropdownOnItemClick } from "@/utils";
 
 export const Header = () => {
   const { data: session, status } = useSession();
-
+  const handleLogout = async () => {
+    await signOut();
+    closeDropdownOnItemClick();
+  };
   return (
     <>
       <header>
@@ -81,17 +85,17 @@ export const Header = () => {
                   tabIndex={0}
                   className="menu menu-sm dropdown-content mt-3 z-[1] p-2 shadow bg-base-100 rounded-box w-52"
                 >
-                  <li>
+                  <li onClick={closeDropdownOnItemClick}>
                     <a>
                       Settings
                       <span className="badge">Soon</span>
                     </a>
                   </li>
-                  <li>
+                  <li onClick={closeDropdownOnItemClick}>
                     <Link href={`/profile`}>Profile</Link>
                   </li>
                   <li>
-                    <a onClick={() => signOut()}>Logout</a>
+                    <a onClick={handleLogout}>Logout</a>
                   </li>
                 </ul>
               </div>

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -8,7 +8,8 @@ import Image from "next/image";
 import Link from "next/link";
 import GitHubCalendar from "react-github-calendar";
 import { Tooltip as ReactTooltip } from "react-tooltip";
-import { exportAsImage } from "@/utils";
+import { ExportOptions } from "@/types/export";
+import { exportAsImage, closeDropdownOnItemClick } from "@/utils";
 
 interface Activity {
   date: string;
@@ -21,6 +22,12 @@ export default function Profile() {
   const [showActivities, setShowActivities] = useState<boolean>(false);
 
   if (!data) return "Loading...";
+
+  const handleExport =
+    (selector: string, option: ExportOptions, filename?: string) => () => {
+      exportAsImage(selector, option, filename);
+      closeDropdownOnItemClick();
+    };
 
   const selectLastHalfYear = (contributions: Activity[]) => {
     const shownMonths = 6;
@@ -52,9 +59,11 @@ export default function Profile() {
             <li>
               <button
                 className="btn-ghost"
-                onClick={() =>
-                  exportAsImage("#profile-card", "download", "profile-card")
-                }
+                onClick={handleExport(
+                  "#profile-card",
+                  "download",
+                  "profile-card"
+                )}
               >
                 Download as PNG
               </button>
@@ -62,7 +71,7 @@ export default function Profile() {
             <li>
               <button
                 className="btn-ghost"
-                onClick={() => exportAsImage("#profile-card", "clipboard")}
+                onClick={handleExport("#profile-card", "clipboard")}
               >
                 Copy to Clipboard
               </button>

--- a/src/utils/closeDropdownOnItemClick.ts
+++ b/src/utils/closeDropdownOnItemClick.ts
@@ -1,0 +1,6 @@
+export const closeDropdownOnItemClick = (): void => {
+  const activeElement = document.activeElement as HTMLElement | null;
+  if (activeElement && activeElement instanceof HTMLElement) {
+    activeElement.blur();
+  }
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+export * from "./closeDropdownOnItemClick";
 export * from "./exportAsImage";
 export * from "./exportAsJSON";
 export * from "./exportAsText";


### PR DESCRIPTION
Added the functionality of closing the dropdown as soon as one of its item is clicked.

There are few repetitions though:
one is about the export dropdown, which can be resolved creating an `ExportDropdownButton` component
the second one is about the use of the `closeDropdownOnItemClick` util function, which is attached to the dropdown  anytime we use it (if we decide to have this functionality throughout the app)

@Balastrong what do you think about these considerations?

I leave the PR on draft for now.
Thank you